### PR TITLE
feat(aip_xx1_description): added cameras 6 and 7

### DIFF
--- a/aip_xx1_description/config/sensor_kit_calibration.yaml
+++ b/aip_xx1_description/config/sensor_kit_calibration.yaml
@@ -41,6 +41,20 @@ sensor_kit_base_link:
     roll: 0.0
     pitch: -0.01
     yaw: 3.125
+  camera6/camera_link:
+    x: 0.396865
+    y: -0.028041
+    z: -0.204267
+    roll: 0.000933
+    pitch: 0.007147
+    yaw: 0.025164
+  camera7/camera_link:
+    x: 0.383094
+    y: 0.020355
+    z: -0.205253
+    roll: 0.011505
+    pitch: -0.017980
+    yaw: 0.034071
   traffic_light_right_camera/camera_link:
     x: 0.05
     y: -0.0175

--- a/aip_xx1_description/urdf/sensor_kit.xacro
+++ b/aip_xx1_description/urdf/sensor_kit.xacro
@@ -197,6 +197,36 @@
       height="400"
       fov="1.3"
     />
+    <xacro:monocular_camera_macro
+      name="camera6/camera"
+      parent="sensor_kit_base_link"
+      namespace=""
+      x="${calibration['sensor_kit_base_link']['camera6/camera_link']['x']}"
+      y="${calibration['sensor_kit_base_link']['camera6/camera_link']['y']}"
+      z="${calibration['sensor_kit_base_link']['camera7/camera_link']['z']}"
+      roll="${calibration['sensor_kit_base_link']['camera6/camera_link']['roll']}"
+      pitch="${calibration['sensor_kit_base_link']['camera6/camera_link']['pitch']}"
+      yaw="${calibration['sensor_kit_base_link']['camera6/camera_link']['yaw']}"
+      fps="30"
+      width="800"
+      height="400"
+      fov="1.3"
+    />
+    <xacro:monocular_camera_macro
+      name="camera7/camera"
+      parent="sensor_kit_base_link"
+      namespace=""
+      x="${calibration['sensor_kit_base_link']['camera7/camera_link']['x']}"
+      y="${calibration['sensor_kit_base_link']['camera7/camera_link']['y']}"
+      z="${calibration['sensor_kit_base_link']['camera7/camera_link']['z']}"
+      roll="${calibration['sensor_kit_base_link']['camera7/camera_link']['roll']}"
+      pitch="${calibration['sensor_kit_base_link']['camera7/camera_link']['pitch']}"
+      yaw="${calibration['sensor_kit_base_link']['camera7/camera_link']['yaw']}"
+      fps="30"
+      width="800"
+      height="400"
+      fov="1.3"
+    />
     <!-- gnss -->
     <xacro:imu_macro
       name="gnss"


### PR DESCRIPTION
Added the ids for cameras 6 and 7 as part of the c1 cameras installation.
The extrinsics corresponds to the ones taken on the 10/25

Signed-off-by: Kenzo Lobos-Tsunekawa <kenzo.lobos@tier4.jp>